### PR TITLE
Implement basic message versioning

### DIFF
--- a/hume.py
+++ b/hume.py
@@ -15,6 +15,8 @@ from humetools import (
 
 
 __version__ = '1.2.28'
+# Version of the hume message format
+MESSAGE_VERSION = 1
 
 
 class Hume():
@@ -54,6 +56,7 @@ class Hume():
         self.reqObj['hume'] = {}
         # Mandatory
         self.reqObj['hume']['timestamp'] = self.get_timestamp()
+        self.reqObj['hume']['version'] = MESSAGE_VERSION
         # Stores hume-client hostname. Should not be confused with the
         # humePkt-level hostname that humed stores. In some weird
         # instances hume and humed might be running in different machines.


### PR DESCRIPTION
## Summary
- embed MESSAGE_VERSION in hume client messages
- validate incoming hume packet version and fields in humed daemon

## Testing
- `python3 -m py_compile hume.py humed.py humetools.py humeconfig.py`

------
https://chatgpt.com/codex/tasks/task_e_684471d189a0832faf98a1deb9006f93