### PR TITLE
Implement plugin support for transfer methods

### DIFF
--- a/humed_plugins/__init__.py
+++ b/humed_plugins/__init__.py
@@ -1,0 +1,21 @@
+import importlib
+import pkgutil
+
+_plugins = {}
+plugin_config_templates = {}
+
+
+def load_plugins():
+    global _plugins, plugin_config_templates
+    for loader, name, is_pkg in pkgutil.iter_modules(__path__):
+        module = importlib.import_module(f"{__name__}.{name}")
+        method = getattr(module, 'TRANSFER_METHOD', name)
+        _plugins[method] = module
+        cfg = getattr(module, 'CONFIG_TEMPLATE', None)
+        if cfg is not None:
+            plugin_config_templates[method] = cfg
+    return _plugins
+
+
+def get_plugin(name):
+    return _plugins.get(name)

--- a/humed_plugins/file.py
+++ b/humed_plugins/file.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+TRANSFER_METHOD = 'file'
+
+CONFIG_TEMPLATE = {
+    'path': 'humed.log'
+}
+
+def send(humepkt=None, config=None):
+    """Append JSON packet to a log file."""
+    path = config.get('path', 'humed.log') if isinstance(config, dict) else 'humed.log'
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'a') as f:
+        f.write(json.dumps(humepkt) + '\n')
+    return True


### PR DESCRIPTION
## Summary
- add new `humed_plugins` package
- implement plugin loader and example file transfer plugin
- integrate plugin loading with `humed`
- allow plugins to extend configuration template
- fix template directory path

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844795d1e28832fa8c74972f1f8b108