### PR TITLE
Add basic CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,51 @@
+import sys
+import os
+import types
+import unittest
+
+# Ensure repository root is on sys.path so local modules can be imported when
+# tests are executed directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide dummy modules so Hume can be imported without optional deps
+for name in ['zmq', 'psutil']:
+    sys.modules[name] = types.ModuleType('dummy')
+
+# Minimal jinja2 stub required by humetools
+jinja2_mod = types.ModuleType('jinja2')
+class Dummy:
+    def __init__(self, *a, **kw):
+        pass
+jinja2_mod.FileSystemLoader = Dummy
+jinja2_mod.Environment = Dummy
+jinja2_mod.TemplateNotFound = Dummy
+jinja2_mod.FunctionLoader = Dummy
+sys.modules['jinja2'] = jinja2_mod
+
+from types import SimpleNamespace
+from hume import Hume
+
+class TestHumeCLI(unittest.TestCase):
+    def test_message_construction(self):
+        args = SimpleNamespace(
+            verbose=False,
+            level='warning',
+            humecmd='',
+            task='TASK1',
+            append_pstree=False,
+            tags=['a', 'b'],
+            encrypt_to=None,
+            recvtimeout=1000,
+            hostname='example.com',
+            extra=None,
+            msg='hello'
+        )
+        h = Hume(args)
+        pkt = h.reqObj
+        self.assertEqual(pkt['hume']['level'], 'warning')
+        self.assertEqual(pkt['hume']['hostname'], 'example.com')
+        self.assertEqual(pkt['hume']['tags'], ['a', 'b'])
+        self.assertEqual(pkt['hume']['msg'], 'hello')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,11 @@
 import sys
+import os
 import types
 import unittest
+
+# Ensure repository root is on sys.path so local modules can be imported when
+# tests are executed directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 # Provide a dummy zmq module so humed can be imported without optional deps
 dummy = types.ModuleType('dummy')


### PR DESCRIPTION
## Summary
- ensure test modules can import repo by adding repo root to `sys.path`
- add a simple CLI test verifying constructed message fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684586c4e9d8832fbb2f90b1aea59c73