### PR TITLE
Implement SaaS REST server

### DIFF
--- a/docs/code_tasks_v2.md
+++ b/docs/code_tasks_v2.md
@@ -21,7 +21,7 @@ This document outlines the main coding tasks required to implement the SaaS orie
 - [x] Allow per-task Slack channel mapping and support multiple simultaneous transfer methods via the plugin system.
 
 ## 4. SaaS Service
-- [ ] Build a server component exposing a REST API to collect events from `humed` instances.
+- [x] Build a server component exposing a REST API to collect events from `humed` instances.
 - [ ] Provide authentication tokens for agents and store incoming events in a central database.
 - [ ] Develop a web dashboard to list and filter stored events.
 - [ ] Extend `humed` so it can forward events to the SaaS API in addition to local transports.

--- a/humesaas.py
+++ b/humesaas.py
@@ -1,0 +1,73 @@
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+
+EVENTS = []
+
+class SaaSHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != '/events':
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get('Content-Length', 0))
+        try:
+            data = json.loads(self.rfile.read(length).decode('utf-8'))
+        except Exception:
+            self.send_response(400)
+            self.end_headers()
+            return
+        EVENTS.append(data)
+        self.send_response(201)
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path != '/events':
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(EVENTS).encode('utf-8'))
+
+    def log_message(self, *a, **kw):
+        pass
+
+class SaaSServer:
+    def __init__(self, host='0.0.0.0', port=8000):
+        self.httpd = HTTPServer((host, port), SaaSHandler)
+        self.thread = Thread(target=self.httpd.serve_forever)
+        self.thread.daemon = True
+
+    @property
+    def server_address(self):
+        return self.httpd.server_address
+
+    def start(self):
+        self.thread.start()
+
+    def stop(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.thread.join()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Hume SaaS server')
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=8000)
+    args = parser.parse_args()
+    server = SaaSServer(args.host, args.port)
+    print(f'Serving on {server.server_address[0]}:{server.server_address[1]}')
+    server.start()
+    try:
+        while True:
+            server.thread.join(1)
+    except KeyboardInterrupt:
+        pass
+    server.stop()
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_saas_server.py
+++ b/tests/test_saas_server.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import unittest
+import json
+import urllib.request
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from humesaas import SaaSServer, EVENTS
+
+class TestSaaSServer(unittest.TestCase):
+    def setUp(self):
+        EVENTS.clear()
+        self.server = SaaSServer(port=0)
+        self.server.start()
+        self.port = self.server.server_address[1]
+
+    def tearDown(self):
+        self.server.stop()
+
+    def test_post_and_get(self):
+        data = {'hume': {'version': 1, 'msg': 'hello'}}
+        req = urllib.request.Request(
+            f'http://127.0.0.1:{self.port}/events',
+            data=json.dumps(data).encode('utf-8'),
+            headers={'Content-Type': 'application/json'},
+            method='POST'
+        )
+        urllib.request.urlopen(req).read()
+        resp = urllib.request.urlopen(f'http://127.0.0.1:{self.port}/events').read().decode()
+        items = json.loads(resp)
+        self.assertEqual(items[0], data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add minimal SaaS REST API server
- test SaaS server functionality
- mark REST API server task as complete in roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685344a8e868832fb940476fc50e9af7